### PR TITLE
External signal not canceling retry loop due to confusion

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ module.exports = async function (url, options) {
                     }
                 } catch (error) {
                     if (!shouldRetry(retryOptions, error, null, waitTime, externalSignal)) {
-                        if (error.name === 'AbortError') {
+                        if (error.name === 'AbortError' && !(externalSignal && externalSignal.aborted)) {
                             return reject(new FetchError(`network timeout at ${url}`, 'request-timeout'));
                         } else {
                             return reject(error);

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function isResponseTimedOut(retryOptions) {
 function shouldRetry(retryOptions, error, response, waitTime, externalSignal) {
     // We must immediately return if the external signal is aborted, else default
     // behaviour would have us retry, due to the internal signal.
-    if (externalSignal.aborted) return false;
+    if (externalSignal && externalSignal.aborted) return false;
     if (getTimeRemaining(retryOptions) < waitTime) {
         return false;
     } else if (retryOptions && retryOptions.retryOnHttpError && error != null) {

--- a/index.js
+++ b/index.js
@@ -40,9 +40,13 @@ function isResponseTimedOut(retryOptions) {
  * @param {Object} error error object if the fetch request returned an error
  * @param {Object} response fetch call response
  * @param {Number} wait Amount of time we will wait before retrying next
+ * @param {AbortSignal} externalSignal
  * @returns {Boolean} whether or not to retry the request
  */
-function shouldRetry(retryOptions, error, response, waitTime) {
+function shouldRetry(retryOptions, error, response, waitTime, externalSignal) {
+    // We must immediately return if the external signal is aborted, else default
+    // behaviour would have us retry, due to the internal signal.
+    if (externalSignal.aborted) return false;
     if (getTimeRemaining(retryOptions) < waitTime) {
         return false;
     } else if (retryOptions && retryOptions.retryOnHttpError && error != null) {
@@ -226,7 +230,7 @@ module.exports = async function (url, options) {
 
                 try {
                     const response = await fetch(url, options);
-                    if (shouldRetry(retryOptions, null, response, waitTime)) {
+                    if (shouldRetry(retryOptions, null, response, waitTime, externalSignal)) {
                         console.error(`Retrying in ${waitTime} milliseconds, attempt ${attempt} failed (status ${response.status}): ${response.statusText}`);
                     } else {
                         // response.timeout should reflect the actual timeout
@@ -234,7 +238,7 @@ module.exports = async function (url, options) {
                         return resolve(response);
                     }
                 } catch (error) {
-                    if (!shouldRetry(retryOptions, error, null, waitTime)) {
+                    if (!shouldRetry(retryOptions, error, null, waitTime, externalSignal)) {
                         if (error.name === 'AbortError') {
                             return reject(new FetchError(`network timeout at ${url}`, 'request-timeout'));
                         } else {


### PR DESCRIPTION
* update shouldRetry to fail if externalSignal is aborted
* update error handling to not reskin AbortError as FetchError if we aborted with the externalSignal.
* fully unit test shouldRetry, it's the crux of this library.
* add an e2e test for abort