### PR TITLE
load FetchError from fetch module

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@
 
 const AbortController = require('abort-controller');
 let fetch = require('node-fetch');
-if (typeof fetch.default !== "undefined") fetch = fetch.default
 const {FetchError} = fetch;
+if (typeof fetch.default !== "undefined") fetch = fetch.default
 
 function getTimeRemaining(retryOptions) {
     if (retryOptions && retryOptions.startTime && retryOptions.retryMaxDuration) {


### PR DESCRIPTION
Fixes a problem where `FetchError` (loaded from `node-fetch`) is undefined.